### PR TITLE
Handle the summon-spring-demo PS upgrade to 9.4.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,12 +25,12 @@ services:
       - bridge
 
   conjur-pg:
-    image: postgres:9.3
+    image: postgres:9.4
     networks:
       - conjur
 
   demo-pg:
-    image: postgres:9.3
+    image: postgres:9.4
     ports: [ "5432:5432" ]
     networks:
       - demo


### PR DESCRIPTION
It is a prerequisite for the audit atomicity.
New data type JsonB was introduced in PS9.4 and is used by the audit.